### PR TITLE
fix: evaluate to false when using null starts or ends

### DIFF
--- a/src/expr/eval/mod.rs
+++ b/src/expr/eval/mod.rs
@@ -512,7 +512,7 @@ fn starts(string: Value, substr: Value) -> Result<Value> {
             Ok(Value::Bool(string.starts_with(&prefix)))
         }
 
-        (Value::None, _) => Ok(Value::None),
+        (Value::None, _) => Ok(Value::Bool(false)),
         _ => Err(Error::InvalidType),
     }
 }
@@ -523,7 +523,7 @@ fn ends(string: Value, substr: Value) -> Result<Value> {
             Ok(Value::Bool(string.ends_with(&suffix)))
         }
 
-        (Value::None, _) => Ok(Value::None),
+        (Value::None, _) => Ok(Value::Bool(false)),
         _ => Err(Error::InvalidType),
     }
 }


### PR DESCRIPTION
I don't know if deliberate but I noticed the behavior of `starts` and `ends` differ from the behavior of `in` where a null left hand operand would always evaluate to `false`. Similarly, the `eq` operator returns `false` if left is null.