### PR TITLE
fix: reserve keyword map instead of do

### DIFF
--- a/src/expr/keywords.rs
+++ b/src/expr/keywords.rs
@@ -43,7 +43,7 @@ const KEYWORDS: [&str; 43] = [
     "key",
     "val",
     "for",
-    "do",
+    "map",
     "filter",
 ];
 


### PR DESCRIPTION
As per https://github.com/mendelt/reval/pull/6, the reserved keyword should be `map` instead of `do`. Let me know in case I've misunderstood anything.